### PR TITLE
Fix noarch python and setuptools

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.9'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,9 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
+    - setuptools
   run:
-    - python >={{ python_min }},<3.11
+    - python >={{ python_min }},<3.13
     - autogluon.core =={{ version }}
     - autogluon.features =={{ version }}
     - autogluon.tabular =={{ version }}
@@ -34,8 +35,8 @@ test:
   # commands:
   #   - python -c "from autogluon.version import __version__ as v; assert v == '{{ version }}', f'{v} != {{ version }}'"
   requires:
-    - pip
     - python {{ python_min }}
+    - pip
 
 about:
   home: https://pypi.org/project/autogluon

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,16 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install ./autogluon -vv
-  number: 1
+  number: 2
   script_env:
     - RELEASE=1
 
 requirements:
   host:
-    - python >=3.8,<3.11
+    - python {{ python_min }}
     - pip
   run:
-    - python >=3.8,<3.11
+    - python >={{ python_min }},<3.11
     - autogluon.core =={{ version }}
     - autogluon.features =={{ version }}
     - autogluon.tabular =={{ version }}
@@ -35,6 +35,7 @@ test:
   #   - python -c "from autogluon.version import __version__ as v; assert v == '{{ version }}', f'{v} != {{ version }}'"
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://pypi.org/project/autogluon


### PR DESCRIPTION
Note that autogluon 0.8.3 is for Python >=3.9,<3.13: https://github.com/autogluon/autogluon/blob/master/core/src/autogluon/core/_setup_utils.py#L97

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
